### PR TITLE
Add streaming parser for large logprobs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,15 @@ with open("logprobs.json", "w") as f:
 ```
 
 Place the generated `logprobs.json` next to `logprobs.html` and reload the page to inspect your own data.
+
+## Handling large datasets
+
+For multi‑hundred‑MB `logprobs.json` files you can avoid loading the entire document into memory by processing tokens incrementally. The provided `stream_logprobs.py` script yields tokens one by one using Python's built‑in `json` decoder so only small chunks are kept in RAM.
+
+Example:
+
+```bash
+python3 stream_logprobs.py logprobs.json --limit 5
+```
+
+This prints the first few token objects but scales to arbitrarily large files.

--- a/stream_logprobs.py
+++ b/stream_logprobs.py
@@ -1,0 +1,53 @@
+import json
+import argparse
+from typing import Iterator, Dict
+
+def iter_tokens(path: str) -> Iterator[Dict]:
+    """Yield token objects from a potentially large logprobs.json file."""
+    decoder = json.JSONDecoder()
+    with open(path, 'r', encoding='utf-8') as f:
+        buf = ''
+        # Find the beginning of the tokens array
+        while True:
+            chunk = f.read(8192)
+            if not chunk:
+                return
+            buf += chunk
+            idx = buf.find('"content"')
+            if idx != -1:
+                # Seek to the '[' that opens the token list
+                idx = buf.find('[', idx)
+                if idx != -1:
+                    buf = buf[idx+1:]
+                    break
+        # Stream individual token objects
+        while True:
+            # Read until we can decode one object
+            while True:
+                try:
+                    obj, end = decoder.raw_decode(buf)
+                    yield obj
+                    buf = buf[end:].lstrip()
+                    if buf.startswith(','):
+                        buf = buf[1:].lstrip()
+                    elif buf.startswith(']'):
+                        return
+                except json.JSONDecodeError:
+                    chunk = f.read(8192)
+                    if not chunk:
+                        return
+                    buf += chunk
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Stream tokens from logprobs.json")
+    ap.add_argument('file', help='path to logprobs.json')
+    ap.add_argument('--limit', type=int, help='print only the first N tokens')
+    args = ap.parse_args()
+    for i, token in enumerate(iter_tokens(args.file)):
+        print(token)
+        if args.limit and i + 1 >= args.limit:
+            break
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `stream_logprobs.py` to stream tokens without loading entire JSON
- document handling big files in README

## Testing
- `python3 stream_logprobs.py logprobs.json --limit 2 | head -c 200`

------
https://chatgpt.com/codex/tasks/task_e_687ddc0c8ea0832ab2b9e63b056a7ca6