### PR TITLE
fix missing await in prompt continuation

### DIFF
--- a/logprobs.html
+++ b/logprobs.html
@@ -512,7 +512,8 @@ async function createCompletion(prevId, replaceIdx, newToken, maxTokens) {
 /* ============ CONTINUE (PROMPT ONLY) ============ */
 async function continueFromPromptOnly(maxTokens) {
   const prevId = currentCompletionId;
-  const prev = getCompletionById(prevId);
+  // getCompletionById returns a Promise, so we need to await it here
+  const prev = await getCompletionById(prevId);
   if (!prev) {
     console.error('[ERROR] Cannot continue: previous completion not found');
     showStatus('Nelze pokračovat – chybí aktuální záznam');


### PR DESCRIPTION
## Summary
- prevent TypeError in continuation by awaiting completion lookup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a49e9d89b8832aa74e8a7f94849e22