### PR TITLE
Fix prompt history selection error

### DIFF
--- a/logprobs.html
+++ b/logprobs.html
@@ -808,9 +808,9 @@ function extractPromptText(entry){
   }catch{ return ''; }
 }
 function formatDt(epoch){ try{ if(!epoch) return ''; const d=new Date(Number(epoch)*1000); return d.toLocaleString(); }catch{ return ''; } }
-function openEntryById(id){
+async function openEntryById(id){
   try{
-    const view = getCompletionById(id);
+    const view = await getCompletionById(id);
     if(!view){ showStatus('Záznam nenalezen'); return; }
     allTokens = view.allTokens;
     safeTokens = allTokens.map(t=>t.token);


### PR DESCRIPTION
## Summary
- wait for asynchronous completion retrieval before rendering

## Testing
- `python -m py_compile stream_logprobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68a837daa78c832a862165e11b98f0c9