### PR TITLE
fix repair links prompt length check

### DIFF
--- a/logprobs.html
+++ b/logprobs.html
@@ -930,7 +930,7 @@ async function repairLinks(){
       for (const cand of entries){
         if (cand.entry.id === target.entry.id) continue;
         if (cand.created >= target.created) continue;
-        if (cand.promptTokens.length >= ptoks.length) continue;
+        if (cand.promptTokens.length >= i+1) continue;
         const full = cand.fullTokens;
         if (full.length < prefix.length) continue;
         let ok = true;


### PR DESCRIPTION
## Summary
- ensure repair links ignores completions whose prompts are not shorter than the current prefix

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile stream_logprobs.py`

------
https://chatgpt.com/codex/tasks/task_e_68ac1b117ac4832a868ad9e25561502a