### PR TITLE
Save initial completion so raw data view works

### DIFF
--- a/logprobs.html
+++ b/logprobs.html
@@ -224,8 +224,10 @@ async function loadTokens() {
       throw new Error("Unsupported JSON format");
     }
 
-    const cnt = await idbCount();
-    if (cnt === 0) { await idbPut(firstEntry); await updateSavedCount(); }
+    // Ulož aktuální položku do IndexedDB, aby bylo možné zobrazit její raw data,
+    // i když už existují starší záznamy v historii.
+    await idbPut(firstEntry);
+    await updateSavedCount();
 
     renderTokens(allTokens);
     exportBtn.hidden = false;


### PR DESCRIPTION
## Summary
- Always store the first loaded completion in IndexedDB so its raw JSON can be viewed

## Testing
- `python -m py_compile stream_logprobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac0ce55af8832a8860b854bab7bbd8