### PR TITLE
Add inline raw object editor with JSON validation

### DIFF
--- a/logprobs.html
+++ b/logprobs.html
@@ -45,7 +45,24 @@
     #rawBox { position: fixed; top: 5%; left: 5%; right: 5%; bottom: 5%; background: #fff; box-shadow: 0 10px 30px #0006; display: flex; flex-direction: column; border: 1px solid #ddd; }
     #rawBoxHeader { display: flex; align-items: center; justify-content: space-between; padding: .5rem .75rem; border-bottom: 1px solid #eee; font-weight: 600; }
     #rawClose { border: none; background: transparent; font-size: 20px; line-height: 1; cursor: pointer; }
-    #rawPre { flex: 1; margin: 0; padding: .75rem; overflow: auto; font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; white-space: pre; }
+    #rawText {
+      flex: 1;
+      margin: 0;
+      padding: .75rem;
+      border: 0;
+      outline: none;
+      resize: none;
+      overflow: auto;
+      font: 13px/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      white-space: pre;
+      background: #fff;
+    }
+    #rawText[readonly] {
+      background: #fafafa;
+    }
+    #rawBoxHeader button {
+      margin-left: .5rem;
+    }
 
     /* newline visualization (override) */
     .nl-hit { display:inline-block; width: 1ch; height: 1.2em; vertical-align: baseline; cursor: pointer; }
@@ -85,9 +102,14 @@
     <div id="rawBox">
       <div id="rawBoxHeader">
         <span>Raw object</span>
-        <button id="rawClose" aria-label="Close">×</button>
+        <div>
+          <button id="rawEdit"   aria-label="Edit">Edit</button>
+          <button id="rawSave"   aria-label="Save" hidden>Save</button>
+          <button id="rawCancel" aria-label="Cancel" hidden>Cancel</button>
+          <button id="rawClose"  aria-label="Close">×</button>
+        </div>
       </div>
-      <pre id="rawPre"></pre>
+      <textarea id="rawText" spellcheck="false"></textarea>
     </div>
   </div>
 
@@ -113,8 +135,16 @@ const exportBtn = document.getElementById('exportBtn');
 const clearBtn = document.getElementById('clearBtn');const continueBtn4096 = document.getElementById('continueBtn4096');
 const objectBtn = document.getElementById('objectBtn');
 const rawOverlay = document.getElementById('rawOverlay');
-const rawPre = document.getElementById('rawPre');
-const rawClose = document.getElementById('rawClose');
+const rawText    = document.getElementById('rawText');
+const rawClose   = document.getElementById('rawClose');
+const rawEdit    = document.getElementById('rawEdit');
+const rawSave    = document.getElementById('rawSave');
+const rawCancel  = document.getElementById('rawCancel');
+
+let rawEditMode = false;
+let rawLastText = '';
+let rawEntryId  = null;
+
 const promptsBtn = document.getElementById('promptsBtn');
 const promptsOverlay = document.getElementById('promptsOverlay');
 const promptsClose = document.getElementById('promptsClose');
@@ -940,14 +970,146 @@ async function showCurrentRaw(){
   try{
     const entry = await idbGet(currentCompletionId);
     if(!entry){ showStatus('Nenalezen aktuální záznam'); return; }
-    rawPre.textContent = JSON.stringify(entry, null, 2);
+
+    rawEntryId  = entry.id || null;
+    rawLastText = JSON.stringify(entry, null, 2);
+
+    rawText.value   = rawLastText;
+    rawText.readOnly = true;
+
+    rawEditMode = false;
+    rawEdit.hidden   = false;
+    rawSave.hidden   = true;
+    rawCancel.hidden = true;
+
     rawOverlay.classList.remove('hidden');
-  }catch(err){ showStatus('Chyba při čtení raw dat'); }
+    setTimeout(()=> rawText.scrollTop = 0, 0);
+  }catch(err){
+    showStatus('Chyba při čtení raw dat');
+  }
 }
+
+function enterRawEdit(){
+  rawEditMode = true;
+  rawEdit.hidden   = true;
+  rawSave.hidden   = false;
+  rawCancel.hidden = false;
+  rawText.readOnly = false;
+  rawText.focus();
+}
+
+async function saveRawEdit(){
+  try{
+    const text = rawText.value;
+    let obj;
+    try { obj = JSON.parse(text); }
+    catch(e){ showStatus('Neplatný JSON: ' + e.message); statusEl.classList.add('error'); return; }
+
+    if (!obj || typeof obj !== 'object') {
+      showStatus('Neplatný obsah: očekáván JSON objekt'); statusEl.classList.add('error'); return;
+    }
+
+    // Bezpečnost: pokud chybí id, zastav
+    if (!obj.id || typeof obj.id !== 'string') {
+      showStatus('Objekt musí mít platné "id"'); statusEl.classList.add('error'); return;
+    }
+
+    softValidateEntry(obj);
+
+    // Ulož do IndexedDB
+    await idbPut(obj);
+    await updateSavedCount();
+
+    // Pokud se změnilo ID, přepneme aktuální výběr
+    currentCompletionId = obj.id;
+
+    // Refresh zobrazených tokenů (pokud se uživatel dívá na tento objekt)
+    try {
+      const view = await getCompletionById(currentCompletionId);
+      if (view) {
+        allTokens = view.allTokens;
+        safeTokens = allTokens.map(t=>t.token);
+        renderTokens(allTokens);
+      }
+    } catch {}
+
+    rawLastText = JSON.stringify(obj, null, 2);
+    rawText.value   = rawLastText;
+    rawText.readOnly = true;
+
+    rawEditMode = false;
+    rawEdit.hidden   = false;
+    rawSave.hidden   = true;
+    rawCancel.hidden = true;
+
+    showStatus('Uloženo.');
+  }catch(err){
+    showStatus('Chyba při ukládání'); statusEl.classList.add('error');
+  }
+}
+
+function cancelRawEdit(){
+  rawText.value   = rawLastText;
+  rawText.readOnly = true;
+
+  rawEditMode = false;
+  rawEdit.hidden   = false;
+  rawSave.hidden   = true;
+  rawCancel.hidden = true;
+
+  showStatus('Změny zrušeny');
+}
+
+function softValidateEntry(obj){
+  try{
+    const toks = obj?.prompt?.logprobs?.tokens || [];
+    const ids  = obj?.prompt?.logprobs?.ids || [];
+    if (Array.isArray(toks) && Array.isArray(ids) && ids.length && ids.length !== toks.length) {
+      console.warn('Varování: tokens length != ids length', toks.length, ids.length);
+      showStatus('Varování: tokens a ids mají různou délku');
+    }
+  }catch{}
+}
+
+if (rawEdit)   rawEdit.addEventListener('click', enterRawEdit);
+if (rawSave)   rawSave.addEventListener('click', saveRawEdit);
+if (rawCancel) rawCancel.addEventListener('click', cancelRawEdit);
+
+if (rawClose) rawClose.addEventListener('click', ()=>{
+  if (rawEditMode) {
+    const ok = confirm('Máte neuložené změny. Opravdu zavřít?');
+    if (!ok) return;
+  }
+  rawOverlay.classList.add('hidden');
+});
+
+if (rawOverlay) rawOverlay.addEventListener('click', (e)=>{
+  if (e.target === rawOverlay) {
+    if (rawEditMode) {
+      const ok = confirm('Máte neuložené změny. Opravdu zavřít?');
+      if (!ok) return;
+    }
+    rawOverlay.classList.add('hidden');
+  }
+});
+
+window.addEventListener('keydown', (e)=>{
+  if (rawOverlay.classList.contains('hidden')) return;
+
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    if (rawEditMode) cancelRawEdit();
+    else rawOverlay.classList.add('hidden');
+  }
+
+  const ctrlOrCmd = e.ctrlKey || e.metaKey;
+  if (ctrlOrCmd && e.key.toLowerCase() === 's') {
+    e.preventDefault();
+    if (rawEditMode) saveRawEdit();
+  }
+});
+
 if (objectBtn) objectBtn.addEventListener('click', showCurrentRaw);
-if (rawClose) rawClose.addEventListener('click', ()=> rawOverlay.classList.add('hidden'));
-if (rawOverlay) rawOverlay.addEventListener('click', (e)=>{ if(e.target===rawOverlay) rawOverlay.classList.add('hidden'); });
-window.addEventListener('keydown', (e)=>{ if(e.key==='Escape') rawOverlay.classList.add('hidden'); });
 
 // =========== PROMPTS VIEWER ===========
 function extractPromptText(entry){


### PR DESCRIPTION
## Summary
- Replace raw viewer `<pre>` with editable `<textarea>` and add Edit/Save/Cancel controls
- Style raw overlay text area and header buttons
- Implement inline JSON editor with validation, save to IndexedDB, and keyboard shortcuts

## Testing
- `node --check /tmp/script.js`
- `python -m py_compile stream_logprobs.py && echo DONE`


------
https://chatgpt.com/codex/tasks/task_e_68ac486113d4832aa6ae36a5389b4b76